### PR TITLE
Install RetroArch through Flatpak in User space

### DIFF
--- a/linux-instructions.php
+++ b/linux-instructions.php
@@ -23,7 +23,7 @@
         <pre>yaourt -Sy retroarch-git</pre>
         <h2><a href="http://flatpak.org">Flatpak</a></h2>
         <p>Stable version, hosted by <a href="https://flathub.org">Flathub</a>:</p>
-        <pre>flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo</pre>
-        <pre>flatpak install flathub org.libretro.RetroArch</pre>
+        <pre>flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo</pre>
+        <pre>flatpak install --user flathub org.libretro.RetroArch</pre>
     </div>
 </div>


### PR DESCRIPTION
Having `--user` lets it install without administration required.