### PR TITLE
Update instructions for Flatpak

### DIFF
--- a/linux-instructions.php
+++ b/linux-instructions.php
@@ -21,9 +21,11 @@
         <pre>sudo pacman -Sy retroarch</pre>
         <p>Git version:</p>
         <pre>yaourt -Sy retroarch-git</pre>
-        <h2><a href="http://flatpak.org">Flatpak</a></h2>
-        <p>Stable version, hosted by <a href="https://flathub.org">Flathub</a>:</p>
+        <h2>Flatpak</h2>
+        <p>To <a href="https://www.libretro.com/index.php/retroarch-with-flatpak/">install RetroArch with Flatpak</a>, use the <a href="https://flathub.org">Flathub</a> repository:</p>
         <pre>flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo</pre>
         <pre>flatpak install --user flathub org.libretro.RetroArch</pre>
+        <p>Update to the latest stable:</p>
+        <pre>flatpak update --user</pre>
     </div>
 </div>

--- a/platforms.php
+++ b/platforms.php
@@ -22,7 +22,6 @@
                 <div class="platform">
                     <img src="images/linux.png">
                     <h4>Linux</h4>
-                    <a href="https://www.libretro.com/index.php/retroarch-with-flatpak/">Install with Flatpak</a>
                     <a href="index.php?page=linux-instructions">Installation instructions</a>
                     <a href="https://buildbot.libretro.com/docs/compilation/ubuntu/">Compilation instructions (Ubuntu)</a>
                 </div>


### PR DESCRIPTION
This adds some update instructions. Also removes Flatpak being the first listed link in the Linux install instructions, and moves it to the page itself.

Fixes #7