### PR TITLE
flatpak: Update docs for org.libretro.RetroArch

### DIFF
--- a/linux-instructions.php
+++ b/linux-instructions.php
@@ -26,6 +26,6 @@
         <pre>flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo</pre>
         <pre>flatpak install --user flathub org.libretro.RetroArch</pre>
         <p>Update to the latest stable:</p>
-        <pre>flatpak update --user</pre>
+        <pre>flatpak update --user org.libretro.RetroArch</pre>
     </div>
 </div>


### PR DESCRIPTION
This small change makes the update documentation to be specific about updating only RetroArch.